### PR TITLE
Facebook API verification skeleton

### DIFF
--- a/fb_transform.py
+++ b/fb_transform.py
@@ -1,6 +1,6 @@
-import json, boto3, io
+import json, boto3, io, os
 def handler(event, context):
     message = json.loads(event['Records'][0]['Sns']['Message'])
     s3 = boto3.client('s3')
-    s3.upload_fileobj(io.BytesIO(json.dumps(message).encode()), 'meaningless-bucket', 'api_message.txt')
+    s3.upload_fileobj(io.BytesIO(json.dumps(message).encode()), os.environ['S3_BUCKET'], 'api_message.txt')
     return None

--- a/fb_veri.py
+++ b/fb_veri.py
@@ -1,0 +1,11 @@
+
+def handler(event, context):
+    # Dummy verification lambda, just replies 200 OK every time
+    response = {
+        'statusCode': 200,
+        'body': '',
+        'headers': {
+            'Content-Type': '*/*'
+        }
+    }
+    return response

--- a/fb_veri.py
+++ b/fb_veri.py
@@ -1,6 +1,9 @@
 
 def handler(event, context):
-    # Dummy verification lambda, just replies 200 OK every time
+    # Dummy verification lambda, just replies 200 OK every time.
+    # Will need to pull the verification token and challenge string
+    #  out of event['queryStringParameters'] and verify the first, return
+    #  the second.
     response = {
         'statusCode': 200,
         'body': '',

--- a/template.yml
+++ b/template.yml
@@ -37,6 +37,19 @@ Resources:
       Environment:
         Variables:
           SNS_TOPIC_ARN: !Ref SNSTopic
+  VerificationLambda:
+    Type: AWS::Serverless::Function
+    Properties:
+      FunctionName: !Sub "${TeamName}-${InputService}-Verification"
+      Handler: fb_veri.handler
+      Runtime: python3.6
+      CodeUri: ./
+      Events:
+        FBApi:
+          Type: Api
+          Properties:
+            Path: /PushEvent
+            Method: GET
   TransformLambda:
     Type: AWS::Serverless::Function
     Properties:

--- a/template.yml
+++ b/template.yml
@@ -22,7 +22,7 @@ Resources:
       FunctionName: !Sub "${TeamName}-${InputService}-Ingest"
       Handler: fb_ingest.handler
       Runtime: python3.6
-      CodeUri: ./
+    CodeUri: ./
       Policies:
         Statement:
           - Effect: Allow
@@ -32,7 +32,7 @@ Resources:
         FBApi:
           Type: Api
           Properties:
-            Path: /PushEvent
+            Path: !Sub "/${InputService}-Event"
             Method: POST
       Environment:
         Variables:
@@ -48,7 +48,7 @@ Resources:
         FBApi:
           Type: Api
           Properties:
-            Path: /PushEvent
+            Path: !Sub "/${InputService}-Event"
             Method: GET
   TransformLambda:
     Type: AWS::Serverless::Function

--- a/template.yml
+++ b/template.yml
@@ -22,7 +22,7 @@ Resources:
       FunctionName: !Sub "${TeamName}-${InputService}-Ingest"
       Handler: fb_ingest.handler
       Runtime: python3.6
-    CodeUri: ./
+      CodeUri: ./
       Policies:
         Statement:
           - Effect: Allow


### PR DESCRIPTION
Added API Gateway GET endpoint for Facebook verification with associated Lambda skeleton.

Completely untested, no promises.